### PR TITLE
J# 41583 added Group resource to six extensions

### DIFF
--- a/input/definitions/multiple/StructureDefinition-artifact-editor.xml
+++ b/input/definitions/multiple/StructureDefinition-artifact-editor.xml
@@ -39,6 +39,10 @@
     <type value="element"/>
     <expression value="Element"/>
   </context>
+  <context>
+    <type value="element"/>
+    <expression value="Group"/>
+  </context>
   <type value="Extension"/>
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
   <derivation value="constraint"/>

--- a/input/definitions/multiple/StructureDefinition-artifact-endorser.xml
+++ b/input/definitions/multiple/StructureDefinition-artifact-endorser.xml
@@ -39,6 +39,10 @@
     <type value="element"/>
     <expression value="Element"/>
   </context>
+  <context>
+    <type value="element"/>
+    <expression value="Group"/>
+  </context>
   <type value="Extension"/>
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
   <derivation value="constraint"/>

--- a/input/definitions/multiple/StructureDefinition-artifact-reviewer.xml
+++ b/input/definitions/multiple/StructureDefinition-artifact-reviewer.xml
@@ -39,6 +39,10 @@
     <type value="element"/>
     <expression value="Element"/>
   </context>
+  <context>
+    <type value="element"/>
+    <expression value="Group"/>
+  </context>
   <type value="Extension"/>
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
   <derivation value="constraint"/>

--- a/input/definitions/multiple/StructureDefinition-resource-approvalDate.xml
+++ b/input/definitions/multiple/StructureDefinition-resource-approvalDate.xml
@@ -82,6 +82,10 @@
     <type value="element"/>
     <expression value="NamingSystem"/>
   </context>
+  <context>
+    <type value="element"/>
+    <expression value="Group"/>
+  </context>
   <type value="Extension"/>
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
   <derivation value="constraint"/>

--- a/input/definitions/multiple/StructureDefinition-resource-effectivePeriod.xml
+++ b/input/definitions/multiple/StructureDefinition-resource-effectivePeriod.xml
@@ -82,6 +82,10 @@
     <type value="element"/>
     <expression value="NamingSystem"/>
   </context>
+  <context>
+    <type value="element"/>
+    <expression value="Group"/>
+  </context>
   <type value="Extension"/>
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
   <derivation value="constraint"/>

--- a/input/definitions/multiple/StructureDefinition-resource-lastReviewDate.xml
+++ b/input/definitions/multiple/StructureDefinition-resource-lastReviewDate.xml
@@ -82,6 +82,10 @@
     <type value="element"/>
     <expression value="NamingSystem"/>
   </context>
+  <context>
+    <type value="element"/>
+    <expression value="Group"/>
+  </context>
   <type value="Extension"/>
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
   <derivation value="constraint"/>


### PR DESCRIPTION
J# 41583 "add Group to the context of the extensions which correspond to the additional elements defined on MetadataResource"

- Moved artifact-editor, artifact-endorser, and artifact-reviewer to the multiple folder and added "Group" as a resource that can use the extensions.
- Added "Group" as a resource that can use the extensions for: resource-approvalDate, resource-effectivePeriod, and resource-lastReviewDate.