### PR TITLE
Fhir 41242 - add more generic criteria reference Structure Definition extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ output/
 .index.json
 
 .idea/
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ output/
 /FHIR-extensions.xml
 
 .index.json
+
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ output/
 
 .index.json
 
-.idea
+.idea/

--- a/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
+++ b/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
@@ -44,6 +44,14 @@
   "kind": "complex-type",
   "abstract": false,
   "context": [
+          {
+            "type": "element",
+            "expression": "Measure.group.population"
+          },
+          {
+            "type": "element",
+            "expression": "Measure.group.stratifier"
+          },  
     {
       "type": "element",
       "expression": "MeasureReport.supplementalData"

--- a/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
+++ b/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
@@ -19,7 +19,7 @@
       ]
     }
   ],
-  "description": "Specifies which criteria is the input for calculations.",
+  "description": "Specifies which criteria is the input for calculations. Specifies which criteria a resource was considered for.",
   "jurisdiction": [
     {
       "coding": [

--- a/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
+++ b/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
@@ -8,7 +8,7 @@
   "status": "active",
   "experimental": false,
   "date": "2023-12-15",
-  "publisher": "HL7 International / Clinical Decision Support",
+  "publisher": "HL7 International / Clinical Quality Information",
   "contact": [
     {
       "telecom": [

--- a/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
+++ b/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
@@ -72,7 +72,7 @@
             "code": "uri"
           }
         ],
-        "fixedUri": "http://hl7.org/fhir/StructureDefinition/extension-criteriaReference"
+        "fixedUri": "http://hl7.org/fhir/StructureDefinition/cqf-criteriaReference"
       },
       {
         "id": "Extension.value[x]",

--- a/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
+++ b/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
@@ -30,7 +30,7 @@
       ]
     }
   ],
-  "purpose": "The definition must be able to specify which criteria is the input used.",
+  "purpose": "In cases where multiple populations of a specific type exist (such as continuous variable and ratio measures), measures must be able to identify which specific criteria is intended as the input. In addition, evaluated resources and supplemental data included in the measure report should be able to identify which criteria were responsible for their inclusion in the report. For example, a MedicationRequest reference can point to the denominator criteria to indicate it was considered as part of the evaluation of that criteria.",
   "fhirVersion": "4.0.1",
   "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
   "derivation": "constraint",

--- a/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
+++ b/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "StructureDefinition",
-  "id": "extension-criteriaReference",
+  "id": "criteriaReference",
   "url": "http://hl7.org/fhir/StructureDefinition/criteriaReference",
   "version": "1.0.0",
   "name": "CriteriaReferenceExtension",
@@ -46,7 +46,11 @@
   "context": [
     {
       "type": "element",
-      "expression": "Reference"
+      "expression": "MeasureReport.supplementalData"
+    },
+    {
+      "type": "element",
+      "expression": "MeasureReport.evaluatedResource"
     }
   ],
   "type": "Extension",

--- a/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
+++ b/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
@@ -1,0 +1,84 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "extension-criteriaReference",
+  "url": "http://hl7.org/fhir/StructureDefinition/criteriaReference",
+  "version": "1.0.0",
+  "name": "CriteriaReferenceExtension",
+  "title": "Criteria Reference Extension",
+  "status": "active",
+  "experimental": false,
+  "date": "2023-12-15",
+  "publisher": "HL7 International / Clinical Decision Support",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.hl7.org/Special/committees/dss"
+        }
+      ]
+    }
+  ],
+  "description": "Specifies which criteria is the input for calculations.",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "system": "urn:iso:std:iso:3166",
+          "code": "US"
+        }
+      ]
+    }
+  ],
+  "purpose": "The definition must be able to specify which criteria is the input used.",
+  "fhirVersion": "4.0.1",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+  "derivation": "constraint",
+  "mapping": [
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    }
+  ],
+  "kind": "complex-type",
+  "abstract": false,
+  "context": [
+    {
+      "type": "element",
+      "expression": "Reference"
+    }
+  ],
+  "type": "Extension",
+  "differential": {
+    "element": [
+      {
+        "id": "Extension",
+        "path": "Extension",
+        "short": "Criteria reference",
+        "definition": "Reference a criteria by specifying that criteria's unique id",
+        "min": 0,
+        "max": "*"
+      },
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "type": [
+          {
+            "code": "uri"
+          }
+        ],
+        "fixedUri": "http://hl7.org/fhir/StructureDefinition/extension-criteriaReference"
+      },
+      {
+        "id": "Extension.value[x]",
+        "path": "Extension.value[x]",
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
+++ b/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
@@ -1,7 +1,7 @@
 {
   "resourceType": "StructureDefinition",
   "id": "criteriaReference",
-  "url": "http://hl7.org/fhir/StructureDefinition/criteriaReference",
+  "url": "http://hl7.org/fhir/StructureDefinition/cqf-criteriaReference",
   "version": "1.0.0",
   "name": "CriteriaReferenceExtension",
   "title": "Criteria Reference Extension",

--- a/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
+++ b/input/definitions/MeasureReport/StructureDefinition-criteriaReference.json
@@ -14,7 +14,7 @@
       "telecom": [
         {
           "system": "url",
-          "value": "http://www.hl7.org/Special/committees/dss"
+          "value": "http://www.hl7.org/Special/committees/cqi"
         }
       ]
     }


### PR DESCRIPTION
A extension structureDefinition for criteria references. http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference and http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-criteriaReference SHOULD be able to use this.
Uncertainties: mapping, jurisdiction, description, purpose, and definition.

https://jira.hl7.org/browse/FHIR-41242