### PR TITLE
FHIR-43324 Added measurereport-populationDescription extension

### DIFF
--- a/input/definitions/MeasureReport/StructureDefinition-measureReport-populationDescription.json
+++ b/input/definitions/MeasureReport/StructureDefinition-measureReport-populationDescription.json
@@ -1,0 +1,89 @@
+{
+    "resourceType" : "StructureDefinition",
+    "id" : "measurereport-populationDescription",
+    "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
+        "valueInteger" : 3
+      },
+      {
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+        "valueCode" : "cqi"
+      },
+      {
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "valueCode" : "trial-use"
+      }],
+        "url" : "http://hl7.org/fhir/StructureDefinition/measurereport-populationDescription",
+    "name" : "measurereport-populationDescription",
+    "title" : "Measure Report Population Description",
+    "status" : "active",
+    "experimental" : false,
+    "date" : "2024-02-01",
+    "publisher" : "HL7 International / Clinical Quality Information WG",
+    "contact" : [{
+      "telecom" : [{
+        "system" : "url",
+        "value" : "http://www.hl7.org/Special/committees/cqi"
+      }]
+    }],
+    "description" : "The human readable description of population criteria.",
+    "jurisdiction" : [{
+      "coding" : [{
+        "system" : "urn:iso:std:iso:3166",
+        "code" : "US"
+      }]
+    }],
+    "purpose" : "Provides a description of the population in which this appears.",
+    "fhirVersion" : "4.0.1",
+    "mapping" : [{
+      "identity" : "rim",
+      "uri" : "http://hl7.org/v3",
+      "name" : "RIM Mapping"
+    }],
+    "kind" : "complex-type",
+    "abstract" : false,
+    "context" : [{
+      "type" : "element",
+      "expression" : "MeasureReport.group"
+    },
+    {
+      "type" : "element",
+      "expression" : "MeasureReport.group.population"
+    },
+    {
+      "type" : "element",
+      "expression" : "MeasureReport.stratifier"
+    },
+    {
+      "type" : "element",
+      "expression" : "MeasureReport.supplementalData"
+    }],
+    "type" : "Extension",
+    "baseDefinition" : "http://hl7.org/fhir/StructureDefinition/Extension",
+    "derivation" : "constraint",
+    "differential" : {
+      "element" : [{
+        "id" : "Extension",
+        "path" : "Extension",
+        "short" : "Provides a description of the population in which it appears.",
+        "definition" : "Provides a description of the population in which it appears.",
+        "min" : 0,
+        "max" : "1"
+      },
+      {
+        "id" : "Extension.url",
+        "path" : "Extension.url",
+        "type" : [{
+          "code" : "uri"
+        }],
+        "fixedUri" : "http://hl7.org/fhir/extensions/StructureDefinition-measurereport-populationDescription"
+      },
+      {
+        "id" : "Extension.value[x]",
+        "path" : "Extension.value[x]",
+        "type" : [{
+          "code" : "markdown"
+        }]
+      }]
+    }
+  }

--- a/input/definitions/MeasureReport/StructureDefinition-measureReport-populationDescription.json
+++ b/input/definitions/MeasureReport/StructureDefinition-measureReport-populationDescription.json
@@ -29,11 +29,12 @@
     "description" : "The human readable description of population criteria.",
     "jurisdiction" : [{
       "coding" : [{
-        "system" : "urn:iso:std:iso:3166",
-        "code" : "US"
+        "system" : "http://unstats.un.org/unsd/methods/m49/m49.htm",
+        "code" : "001",
+        "display" : "World"
       }]
     }],
-    "purpose" : "Provides a description of the population in which this appears.",
+    "purpose" : "Provides a description of the population on which this appears.",
     "fhirVersion" : "4.0.1",
     "mapping" : [{
       "identity" : "rim",
@@ -65,8 +66,8 @@
       "element" : [{
         "id" : "Extension",
         "path" : "Extension",
-        "short" : "Provides a description of the population in which it appears.",
-        "definition" : "Provides a description of the population in which it appears.",
+        "short" : "Provides a description of the population on which it appears.",
+        "definition" : "A description of the group, population, stratifier, or supplemental data definition on which it appears. This is typically a restatement of the description of the corresponding element in the Measure being reported, but may also include additional information gathered by the reporting process.",
         "min" : 0,
         "max" : "1"
       },
@@ -76,7 +77,7 @@
         "type" : [{
           "code" : "uri"
         }],
-        "fixedUri" : "http://hl7.org/fhir/extensions/StructureDefinition-measurereport-populationDescription"
+        "fixedUri" : "http://hl7.org/fhir/StructureDefinition/measurereport-populationDescription"
       },
       {
         "id" : "Extension.value[x]",


### PR DESCRIPTION
Controlling FHIR ticket: https://jira.hl7.org/browse/FHIR-43324

Added a measurereport-populationDescription to the registry.  

(The aforementioned FHIR ticket's comments indicate that the extension might be added directly to the DEQM IG on an interim basis to avoid display errors while referencing the extension in the measureReport profiles.  After further discussion, it was decided to, instead, add the extension to this registry IG as described in the ticket's resolution, accepting the fact that those display errors will be present in the DEQM IG until this registry is next published. )