### PR TITLE
FHIR-43089 - added countQuantity StructureDefinition

### DIFF
--- a/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
+++ b/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
@@ -50,7 +50,6 @@
         "path": "Extension",
         "short": "Size of the population as a quantity.",
         "definition": "A Quantity representing the size of the population. This is important to support the case when a population value may result in a decimal when reporting composite measures.",
-        "comment": "The 'date' element may be more recent than the approval date because of minor changes or editorial corrections.",
         "min": 0,
         "max": "1"
       },

--- a/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
+++ b/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
@@ -61,7 +61,7 @@
             "code": "uri"
           }
         ],
-        "fixedUri": "http://hl7.org/fhir/StructureDefinition/countQuantity"
+        "fixedUri": "http://hl7.org/fhir/StructureDefinition/measurereport-countQuantity"
       },
       {
         "id": "Extension.value[x]",

--- a/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
+++ b/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
@@ -39,7 +39,7 @@
     },
     {
       "type": "element",
-      "expression": "MeasureReport.evaluatedResource"
+      "expression": "MeasureReport.group.stratifier.stratum.population.count"
     }
   ],
   "type": "Extension",

--- a/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
+++ b/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
@@ -1,0 +1,78 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "countQuantity",
+  "url": "http://hl7.org/fhir/StructureDefinition/countQuantity",
+  "name": "CountQuantity",
+  "title": "Count Quantity",
+  "status": "active",
+  "experimental": false,
+  "date": "2024-01-08T13:31:32-07:00",
+  "publisher": "HL7 International / Clinical Decision Support",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.hl7.org/Special/committees/dss"
+        }
+      ]
+    }
+  ],
+  "description": "Size of the population as a quantity.",
+  "purpose": "To provide support for reporting composite measures that may result in decimal-valued counts for populations.",
+  "fhirVersion": "4.0.1",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+  "derivation": "constraint",
+  "mapping": [
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    }
+  ],
+  "kind": "complex-type",
+  "abstract": false,
+  "context": [
+    {
+      "type": "element",
+      "expression": "MeasureReport.group.population.count"
+    },
+    {
+      "type": "element",
+      "expression": "MeasureReport.evaluatedResource"
+    }
+  ],
+  "type": "Extension",
+  "differential": {
+    "element": [
+      {
+        "id": "Extension",
+        "path": "Extension",
+        "short": "Size of the population as a quantity.",
+        "definition": "A decimal representation of the size of the population.",
+        "comment": "The 'date' element may be more recent than the approval date because of minor changes or editorial corrections.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "type": [
+          {
+            "code": "uri"
+          }
+        ],
+        "fixedUri": "http://hl7.org/fhir/StructureDefinition/countQuantity"
+      },
+      {
+        "id": "Extension.value[x]",
+        "path": "Extension.value[x]",
+        "type": [
+          {
+            "code": "decimal"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
+++ b/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
@@ -1,7 +1,7 @@
 {
   "resourceType": "StructureDefinition",
   "id": "countQuantity",
-  "url": "http://hl7.org/fhir/StructureDefinition/countQuantity",
+  "url": "http://hl7.org/fhir/StructureDefinition/measurereport-countQuantity",
   "name": "CountQuantity",
   "title": "Count Quantity",
   "status": "active",

--- a/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
+++ b/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
@@ -68,7 +68,7 @@
         "path": "Extension.value[x]",
         "type": [
           {
-            "code": "decimal"
+            "code": "Quantity"
           }
         ]
       }

--- a/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
+++ b/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
@@ -49,7 +49,7 @@
         "id": "Extension",
         "path": "Extension",
         "short": "Size of the population as a quantity.",
-        "definition": "A decimal representation of the size of the population.",
+        "definition": "A Quantity representing the size of the population. This is important to support the case when a population value may result in a decimal when reporting composite measures.",
         "comment": "The 'date' element may be more recent than the approval date because of minor changes or editorial corrections.",
         "min": 0,
         "max": "1"

--- a/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
+++ b/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
@@ -13,7 +13,7 @@
       "telecom": [
         {
           "system": "url",
-          "value": "http://www.hl7.org/Special/committees/dss"
+          "value": "http://www.hl7.org/Special/committees/cqi"
         }
       ]
     }

--- a/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
+++ b/input/definitions/MeasureReport/StructureDefinition-countQuantity.json
@@ -7,7 +7,7 @@
   "status": "active",
   "experimental": false,
   "date": "2024-01-08T13:31:32-07:00",
-  "publisher": "HL7 International / Clinical Decision Support",
+  "publisher": "HL7 International / Clinical Quality Information",
   "contact": [
     {
       "telecom": [


### PR DESCRIPTION
A extension structureDefinition for countQuantity as a decimal. Use a cross-version extension to incorporate the new countQuantity element from MeasureReport to provide support for reporting composite measures that may result in decimal-valued counts for populations.


https://jira.hl7.org/browse/FHIR-43089