### PR TITLE
Remove not-selectable SHOULD:populate

### DIFF
--- a/input/definitions/CapabilityStatement/StructureDefinition-capabilitystatement-search-mode.xml
+++ b/input/definitions/CapabilityStatement/StructureDefinition-capabilitystatement-search-mode.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/fiwg"/>
     </telecom>
   </contact>
-  <description value="Which search modes the server supports: GET, POST, or both"/>
+  <description value="Which search modes the server supports: GET, POST, or both."/>
   <fhirVersion value="5.0.0"/>
   <kind value="complex-type"/>
   <abstract value="false"/>
@@ -44,7 +44,7 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="Search mode Supported: GET, POST, or both"/>
-      <definition value="Which search modes the server supports: GET, POST, or both"/>
+      <definition value="Which search modes the server supports: GET, POST, or both."/>
       <comment value="Used for web-socket based subscriptions."/>
       <min value="0"/>
       <max value="1"/>

--- a/input/definitions/Composition/StructureDefinition-composition-section-subject.xml
+++ b/input/definitions/Composition/StructureDefinition-composition-section-subject.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/structure"/>
     </telecom>
   </contact>
-  <description value="Specifies that the section has a different subject that the Composition, or it's container section."/>
+  <description value="Specifies that the section has a different subject than the Composition, or its container section."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>
@@ -48,8 +48,8 @@
   <differential>
     <element id="Extension">
       <path value="Extension"/>
-      <short value="Section has a different subject that it's container"/>
-      <definition value="Specifies that the section has a different subject that the Composition, or it's container section."/>
+      <short value="Section has a different subject than its container"/>
+      <definition value="Specifies that the section has a different subject than the Composition, or its container section."/>
       <comment value="This is used in various FHIR value sets to make comments on how particular codes are used when the formal definition is a little abstract or vague, but it's not clear whether it belongs in the actual value set resource."/>
       <min value="0"/>
       <max value="1"/>

--- a/input/definitions/Element/StructureDefinition-artifact-canonicalReference.json
+++ b/input/definitions/Element/StructureDefinition-artifact-canonicalReference.json
@@ -31,7 +31,7 @@
       "value" : "http://www.hl7.org/Special/committees/dss"
     }]
   }],
-  "description" : "A reference to a canonical resource",
+  "description" : "A reference to a canonical resource.",
   "purpose" : "To allow resources to define a reference to a canonical resource.",
   "fhirVersion" : "4.0.1",
   "kind" : "complex-type",

--- a/input/definitions/Element/StructureDefinition-artifact-reference.json
+++ b/input/definitions/Element/StructureDefinition-artifact-reference.json
@@ -31,7 +31,7 @@
       "value" : "http://www.hl7.org/Special/committees/dss"
     }]
   }],
-  "description" : "A reference to a resource, canonical resource, or non-FHIR resource",
+  "description" : "A reference to a resource, canonical resource, or non-FHIR resource.",
   "purpose" : "To allow resources to define a reference to a resource, canonical resource, or non-FHIR resource.",
   "fhirVersion" : "4.0.1",
   "kind" : "complex-type",

--- a/input/definitions/List/StructureDefinition-list-category.xml
+++ b/input/definitions/List/StructureDefinition-list-category.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/fiwg"/>
     </telecom>
   </contact>
-  <description value="A categorization for the type of the list - helps for indexing and searching"/>
+  <description value="A categorization for the type of the list - helps for indexing and searching."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>
@@ -49,7 +49,7 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="Base List for changes"/>
-      <definition value="A categorization for the type of the list - helps for indexing and searching"/>
+      <definition value="A categorization for the type of the list - helps for indexing and searching."/>
       <min value="0"/>
       <max value="1"/>
     </element>

--- a/input/definitions/OperationOutcome/StructureDefinition-operationoutcome-file.xml
+++ b/input/definitions/OperationOutcome/StructureDefinition-operationoutcome-file.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/fiwg"/>
     </telecom>
   </contact>
-  <description value="Identifies the source file where the issue is found (when there are multiple source files)"/>
+  <description value="Identifies the source file where the issue is found (when there are multiple source files)."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>

--- a/input/definitions/OperationOutcome/StructureDefinition-operationoutcome-issue-col.xml
+++ b/input/definitions/OperationOutcome/StructureDefinition-operationoutcome-issue-col.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/fiwg"/>
     </telecom>
   </contact>
-  <description value="Identifies the source column for the issue"/>
+  <description value="Identifies the source column for the issue."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>

--- a/input/definitions/OperationOutcome/StructureDefinition-operationoutcome-issue-line.xml
+++ b/input/definitions/OperationOutcome/StructureDefinition-operationoutcome-issue-line.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/fiwg"/>
     </telecom>
   </contact>
-  <description value="Identifies the source line of the issue"/>
+  <description value="Identifies the source line of the issue."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>

--- a/input/definitions/OperationOutcome/StructureDefinition-operationoutcome-issue-source.xml
+++ b/input/definitions/OperationOutcome/StructureDefinition-operationoutcome-issue-source.xml
@@ -29,8 +29,8 @@
       <value value="http://www.hl7.org/Special/committees/fiwg"/>
     </telecom>
   </contact>
-  <description value="Identifies the logical module/software section responsible for identifying the issue"/>
-  <purpose value="When debugging issues, it's helpful to know where within the logic stack an issue was identified"/>
+  <description value="Identifies the logical module/software section responsible for identifying the issue."/>
+  <purpose value="When debugging issues, it's helpful to know where within the logic stack an issue was identified."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>
@@ -51,7 +51,7 @@
       <path value="Extension"/>
       <short value="Source of a validation message"/>
       <definition value="Identifies the logical module/software section responsible for identifying the issue."/>
-      <comment value="This is a high-level category. Information such as a stack track should be conveyed in the issue.detail"/>
+      <comment value="This is a high-level category. Information such as a stack track should be conveyed in the issue.detail."/>
       <min value="0"/>
       <max value="1"/>
     </element>

--- a/input/definitions/OperationOutcome/StructureDefinition-operationoutcome-message-id.xml
+++ b/input/definitions/OperationOutcome/StructureDefinition-operationoutcome-message-id.xml
@@ -29,8 +29,8 @@
       <value value="http://www.hl7.org/Special/committees/fiwg"/>
     </telecom>
   </contact>
-  <description value="Identifies the id of the source message used to construct the actual error message"/>
-  <purpose value="This is typically used for sorting and filtering messages"/>
+  <description value="Identifies the id of the source message used to construct the actual error message."/>
+  <purpose value="This is typically used for sorting and filtering messages."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>
@@ -50,7 +50,7 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="Source of a validation message"/>
-      <definition value="Identifies the id of the source message used to construct the actual error message"/>
+      <definition value="Identifies the id of the source message used to construct the actual error message."/>
       <min value="0"/>
       <max value="1"/>
     </element>

--- a/input/definitions/QuestionnaireResponse/StructureDefinition-questionnaireresponse-attester.xml
+++ b/input/definitions/QuestionnaireResponse/StructureDefinition-questionnaireresponse-attester.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/fiwg"/>
     </telecom>
   </contact>
-  <description value="Allows capturing the individual(s) who attest to the accuracy of the information within the QuestionnaireResponse"/>
+  <description value="Allows capturing the individual(s) who attest to the accuracy of the information within the QuestionnaireResponse."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>
@@ -50,7 +50,7 @@
       <path value="Extension"/>
       <short value="Who attests to answers"/>
       <definition value="Allows capturing, on a specific question or group of questions, exactly who was responsible for providing the answer(s)."/>
-      <comment value="Multiple atttestations are possible - potentially of different types"/>
+      <comment value="Multiple atttestations are possible - potentially of different types."/>
       <min value="0"/>
       <max value="*"/>
     </element>

--- a/input/definitions/Resource/StructureDefinition-artifact-author.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-author.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="An individiual or organization primarily involved in the creation and maintenance of the {{title}}."/>
+  <description value="An individual or organization primarily involved in the creation and maintenance of the {{title}}."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already metadata resources that have the author element, but that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -50,7 +50,7 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="Who authored the {{title}}"/>
-      <definition value="An individiual or organization primarily involved in the creation and maintenance of the {{title}}."/>
+      <definition value="An individual or organization primarily involved in the creation and maintenance of the {{title}}."/>
       <min value="0"/>
       <max value="*"/>
     </element>

--- a/input/definitions/Resource/StructureDefinition-artifact-author.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-author.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="An individual or organization primarily involved in the creation and maintenance of the {{title}}."/>
+  <description value="An individual or organization primarily involved in the creation and maintenance of the artifact."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already metadata resources that have the author element, but that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -49,8 +49,8 @@
   <differential>
     <element id="Extension">
       <path value="Extension"/>
-      <short value="Who authored the {{title}}"/>
-      <definition value="An individual or organization primarily involved in the creation and maintenance of the {{title}}."/>
+      <short value="Who authored the artifact"/>
+      <definition value="An individual or organization primarily involved in the creation and maintenance of the artifact."/>
       <min value="0"/>
       <max value="*"/>
     </element>

--- a/input/definitions/Resource/StructureDefinition-artifact-copyright.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-copyright.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="A copyright statement relating to the {{title}} and/or its contents. Copyright statements are generally legal restrictions on the use and publishing of the {{title}}."/>
+  <description value="A copyright statement relating to the artifact and/or its contents. Copyright statements are generally legal restrictions on the use and publishing of the artifact."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -50,7 +50,7 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="Use and/or publishing restrictions"/>
-      <definition value="A copyright statement relating to the {{title}} and/or its contents. Copyright statements are generally legal restrictions on the use and publishing of the {{title}}."/>
+      <definition value="A copyright statement relating to the artifact and/or its contents. Copyright statements are generally legal restrictions on the use and publishing of the artifact."/>
       <comment value="The short copyright declaration (e.g. (c) '2015+ xyz organization' should be sent in the copyrightLabel element."/>
       <min value="0"/>
       <max value="1"/>

--- a/input/definitions/Resource/StructureDefinition-artifact-date.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-date.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="The date  (and optionally time) when the {{title}} was last significantly changed. The date must change when the business version changes and it must change if the status code changes. In addition, it should change when the substantive content of the {{title}} changes."/>
+  <description value="The date  (and optionally time) when the artifact was last significantly changed. The date must change when the business version changes and it must change if the status code changes. In addition, it should change when the substantive content of the artifact changes."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -50,8 +50,8 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="Date last changed"/>
-      <definition value="The date  (and optionally time) when the {{title}} was last significantly changed. The date must change when the business version changes and it must change if the status code changes. In addition, it should change when the substantive content of the {{title}} changes."/>
-      <comment value="The date is often not tracked until the resource is published, but may be present on draft content. Note that this is not the same as the resource last-modified-date, since the resource may be a secondary representation of the {{title}}. Additional specific dates may be added as extensions or be found by consulting Provenances associated with past versions of the resource."/>
+      <definition value="The date  (and optionally time) when the artifact was last significantly changed. The date must change when the business version changes and it must change if the status code changes. In addition, it should change when the substantive content of the artifact changes."/>
+      <comment value="The date is often not tracked until the resource is published, but may be present on draft content. Note that this is not the same as the resource last-modified-date, since the resource may be a secondary representation of the artifact. Additional specific dates may be added as extensions or be found by consulting Provenances associated with past versions of the resource."/>
       <min value="0"/>
       <max value="1"/>
     </element>

--- a/input/definitions/Resource/StructureDefinition-artifact-description.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-description.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="A free text natural language description of the {{title}} from a consumer's perspective."/>
+  <description value="A free text natural language description of the artifact from a consumer's perspective."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -49,9 +49,9 @@
   <differential>
     <element id="Extension">
       <path value="Extension"/>
-      <short value="Natural language description of the {{title}}"/>
-      <definition value="A free text natural language description of the {{title}} from a consumer's perspective."/>
-      <comment value="This description can be used to capture details such as comments about misuse, instructions for clinical use and interpretation, literature references, examples from the paper world, etc. It is not a rendering of the {{title}} as conveyed in the 'text' field of the resource itself. This item SHOULD be populated unless the information is available from context (e.g. the language of the {{title}} is presumed to be the predominant language in the place the {{title}} was created)."/>
+      <short value="Natural language description of the artifact"/>
+      <definition value="A free text natural language description of the artifact from a consumer's perspective."/>
+      <comment value="This description can be used to capture details such as comments about misuse, instructions for clinical use and interpretation, literature references, examples from the paper world, etc. It is not a rendering of the artifact as conveyed in the 'text' field of the resource itself. This item SHOULD be populated unless the information is available from context (e.g. the language of the artifact is presumed to be the predominant language in the place the artifact was created)."/>
       <min value="0"/>
       <max value="1"/>
     </element>

--- a/input/definitions/Resource/StructureDefinition-artifact-experimental.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-experimental.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="A Boolean value to indicate that this {{title}} is authored for testing purposes (or education/evaluation/marketing) and is not intended to be used for genuine usage."/>
+  <description value="A Boolean value to indicate that this artifact is authored for testing purposes (or education/evaluation/marketing) and is not intended to be used for genuine usage."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -50,7 +50,7 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="For testing purposes, not real usage"/>
-      <definition value="A Boolean value to indicate that this {{title}} is authored for testing purposes (or education/evaluation/marketing) and is not intended to be used for genuine usage."/>
+      <definition value="A Boolean value to indicate that this artifact is authored for testing purposes (or education/evaluation/marketing) and is not intended to be used for genuine usage."/>
       <min value="0"/>
       <max value="1"/>
     </element>

--- a/input/definitions/Resource/StructureDefinition-artifact-identifier.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-identifier.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="A formal identifier that is used to identify this {{title}} when it is represented in other formats, or referenced in a specification, model, design or an instance."/>
+  <description value="A formal identifier that is used to identify this artifact when it is represented in other formats, or referenced in a specification, model, design or an instance."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -49,9 +49,9 @@
   <differential>
     <element id="Extension">
       <path value="Extension"/>
-      <short value="Additional identifier for the {{title}}"/>
-      <definition value="A formal identifier that is used to identify this {{title}} when it is represented in other formats, or referenced in a specification, model, design or an instance."/>
-      <comment value="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this {{title}} outside of FHIR, where it is not possible to use the logical URI."/>
+      <short value="Additional identifier for the artifact"/>
+      <definition value="A formal identifier that is used to identify this artifact when it is represented in other formats, or referenced in a specification, model, design or an instance."/>
+      <comment value="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this artifact outside of FHIR, where it is not possible to use the logical URI."/>
       <min value="0"/>
       <max value="*"/>
     </element>

--- a/input/definitions/Resource/StructureDefinition-artifact-jurisdiction.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-jurisdiction.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="A legal or geographic region in which the {{title}} is intended to be used."/>
+  <description value="A legal or geographic region in which the artifact is intended to be used."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -49,9 +49,9 @@
   <differential>
     <element id="Extension">
       <path value="Extension"/>
-      <short value="Intended jurisdiction for {{title}} (if applicable)"/>
-      <definition value="A legal or geographic region in which the {{title}} is intended to be used."/>
-      <comment value="It may be possible for the {{title}} to be used in jurisdictions other than those for which it was originally designed or intended."/>
+      <short value="Intended jurisdiction for artifact (if applicable)"/>
+      <definition value="A legal or geographic region in which the artifact is intended to be used."/>
+      <comment value="It may be possible for the artifact to be used in jurisdictions other than those for which it was originally designed or intended."/>
       <min value="0"/>
       <max value="*"/>
     </element>

--- a/input/definitions/Resource/StructureDefinition-artifact-name.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-name.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="A natural language name identifying the {{title}}. This name should be usable as an identifier for the module by machine processing applications such as code generation."/>
+  <description value="A natural language name identifying the artifact. This name should be usable as an identifier for the module by machine processing applications such as code generation."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -49,8 +49,8 @@
   <differential>
     <element id="Extension">
       <path value="Extension"/>
-      <short value="Name for this {{title}} (computer friendly)"/>
-      <definition value="A natural language name identifying the {{title}}. This name should be usable as an identifier for the module by machine processing applications such as code generation."/>
+      <short value="Name for this artifact (computer friendly)"/>
+      <definition value="A natural language name identifying the artifact. This name should be usable as an identifier for the module by machine processing applications such as code generation."/>
       <comment value="The name is not expected to be globally unique. The name should be a simple alphanumeric type name to ensure that it is machine-processing friendly."/>
       <min value="0"/>
       <max value="1"/>

--- a/input/definitions/Resource/StructureDefinition-artifact-publisher.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-publisher.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="The name of the organization or individual responsible for the release and ongoing maintenance of the {{title}}."/>
+  <description value="The name of the organization or individual responsible for the release and ongoing maintenance of the artifact."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -50,8 +50,8 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="Name of the publisher/steward (organization or individual)"/>
-      <definition value="The name of the organization or individual responsible for the release and ongoing maintenance of the {{title}}."/>
-      <comment value="Usually an organization but may be an individual. The publisher (or steward) of the {{title}} is the organization or individual primarily responsible for the maintenance and upkeep of the {{title}}. This is not necessarily the same individual or organization that developed and initially authored the content. The publisher is the primary point of contact for questions or issues with the {{title}}. This item SHOULD be populated unless the information is available from context."/>
+      <definition value="The name of the organization or individual responsible for the release and ongoing maintenance of the artifact."/>
+      <comment value="Usually an organization but may be an individual. The publisher (or steward) of the artifact is the organization or individual primarily responsible for the maintenance and upkeep of the artifact. This is not necessarily the same individual or organization that developed and initially authored the content. The publisher is the primary point of contact for questions or issues with the artifact. This item SHOULD be populated unless the information is available from context."/>
       <min value="0"/>
       <max value="1"/>
     </element>

--- a/input/definitions/Resource/StructureDefinition-artifact-purpose.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-purpose.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="Explanation of why this {{title}} is needed and why it has been designed as it has."/>
+  <description value="Explanation of why this artifact is needed and why it has been designed as it has."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -49,9 +49,9 @@
   <differential>
     <element id="Extension">
       <path value="Extension"/>
-      <short value="Why this {{title}} is defined"/>
-      <definition value="Explanation of why this {{title}} is needed and why it has been designed as it has."/>
-      <comment value="This element does not describe the usage of the {{title}}. Instead, it provides traceability of ''why'' the resource is either needed or ''why'' it is defined as it is.  This may be used to point to source materials or specifications that drove the structure of this {{title}}."/>
+      <short value="Why this artifact is defined"/>
+      <definition value="Explanation of why this artifact is needed and why it has been designed as it has."/>
+      <comment value="This element does not describe the usage of the artifact. Instead, it provides traceability of ''why'' the resource is either needed or ''why'' it is defined as it is.  This may be used to point to source materials or specifications that drove the structure of this artifact."/>
       <min value="0"/>
       <max value="1"/>
     </element>

--- a/input/definitions/Resource/StructureDefinition-artifact-status.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-status.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="The status of this {{title}}. Enables tracking the life-cycle of the content."/>
+  <description value="The status of this artifact. Enables tracking the life-cycle of the content."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -50,7 +50,7 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="draft | active | retired | unknown"/>
-      <definition value="The status of this {{title}}. Enables tracking the life-cycle of the content."/>
+      <definition value="The status of this artifact. Enables tracking the life-cycle of the content."/>
       <min value="0"/>
       <max value="1"/>
       <isModifier value="true"/>

--- a/input/definitions/Resource/StructureDefinition-artifact-title.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-title.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="A short, descriptive, user-friendly title for the {{title}}."/>
+  <description value="A short, descriptive, user-friendly title for the artifact."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -49,8 +49,8 @@
   <differential>
     <element id="Extension">
       <path value="Extension"/>
-      <short value="Name for this {{title}} (human friendly)"/>
-      <definition value="A short, descriptive, user-friendly title for the {{title}}."/>
+      <short value="Name for this artifact (human friendly)"/>
+      <definition value="A short, descriptive, user-friendly title for the artifact."/>
       <comment value="This name does not need to be machine-processing friendly and may contain punctuation, white-space, etc."/>
       <min value="0"/>
       <max value="1"/>

--- a/input/definitions/Resource/StructureDefinition-artifact-topic.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-topic.xml
@@ -51,7 +51,7 @@
       <path value="Extension"/>
       <short value="E.g. Education, Treatment, Assessment, etc."/>
       <definition value="Descriptive topics related to the content of the artifact. Topics provide a high-level categorization of the artifact that can be useful for filtering and searching."/>
-      <comment value="This element provides a topical categorization of the {{title}}, as opposed to the more structured context-of-use information provided in the useContext element."/>
+      <comment value="This element provides a topical categorization of the artifact, as opposed to the more structured context-of-use information provided in the useContext element."/>
       <min value="0"/>
       <max value="*"/>
     </element>

--- a/input/definitions/Resource/StructureDefinition-artifact-url.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-url.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="An absolute URI that is used to identify this {{title}} when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which an authoritative instance of this {{title}} is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the {{title}} is stored on different servers."/>
+  <description value="An absolute URI that is used to identify this artifact when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which an authoritative instance of this artifact is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the artifact is stored on different servers."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -49,8 +49,8 @@
   <differential>
     <element id="Extension">
       <path value="Extension"/>
-      <short value="Canonical identifier for this {{title}}, represented as a URI (globally unique)"/>
-      <definition value="An absolute URI that is used to identify this {{title}} when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which an authoritative instance of this {{title}} is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the {{title}} is stored on different servers."/>
+      <short value="Canonical identifier for this artifact, represented as a URI (globally unique)"/>
+      <definition value="An absolute URI that is used to identify this artifact when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which an authoritative instance of this artifact is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the artifact is stored on different servers."/>
       <comment value="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xA;&#xA;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xA;&#xA;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <min value="0"/>
       <max value="1"/>

--- a/input/definitions/Resource/StructureDefinition-artifact-useContext.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-useContext.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="The content was developed with a focus and intent of supporting the contexts that are listed. These contexts may be general categories (gender, age, ...) or may be references to specific programs (insurance plans, studies, ...) and may be used to assist with indexing and searching for appropriate {{title}} instances."/>
+  <description value="The content was developed with a focus and intent of supporting the contexts that are listed. These contexts may be general categories (gender, age, ...) or may be references to specific programs (insurance plans, studies, ...) and may be used to assist with indexing and searching for appropriate artifact instances."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -50,7 +50,7 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="The context that the content is intended to support"/>
-      <definition value="The content was developed with a focus and intent of supporting the contexts that are listed. These contexts may be general categories (gender, age, ...) or may be references to specific programs (insurance plans, studies, ...) and may be used to assist with indexing and searching for appropriate {{title}} instances."/>
+      <definition value="The content was developed with a focus and intent of supporting the contexts that are listed. These contexts may be general categories (gender, age, ...) or may be references to specific programs (insurance plans, studies, ...) and may be used to assist with indexing and searching for appropriate artifact instances."/>
       <comment value="When multiple useContexts are specified, there is no expectation that all or any of the contexts apply."/>
       <min value="0"/>
       <max value="*"/>

--- a/input/definitions/Resource/StructureDefinition-artifact-version.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-version.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="The identifier that is used to identify this version of the {{title}} when it is referenced in a specification, model, design or instance. This is an arbitrary value managed by the {{title}} author and is not expected to be globally unique. For example, it might be a timestamp (e.g. yyyymmdd) if a managed version is not available. There is also no expectation that versions can be placed in a lexicographical sequence."/>
+  <description value="The identifier that is used to identify this version of the artifact when it is referenced in a specification, model, design or instance. This is an arbitrary value managed by the artifact author and is not expected to be globally unique. For example, it might be a timestamp (e.g. yyyymmdd) if a managed version is not available. There is also no expectation that versions can be placed in a lexicographical sequence."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -49,8 +49,8 @@
   <differential>
     <element id="Extension">
       <path value="Extension"/>
-      <short value="Business version of the {{title}}"/>
-      <definition value="The identifier that is used to identify this version of the {{title}} when it is referenced in a specification, model, design or instance. This is an arbitrary value managed by the {{title}} author and is not expected to be globally unique. For example, it might be a timestamp (e.g. yyyymmdd) if a managed version is not available. There is also no expectation that versions can be placed in a lexicographical sequence."/>
+      <short value="Business version of the artifact"/>
+      <definition value="The identifier that is used to identify this version of the artifact when it is referenced in a specification, model, design or instance. This is an arbitrary value managed by the artifact author and is not expected to be globally unique. For example, it might be a timestamp (e.g. yyyymmdd) if a managed version is not available. There is also no expectation that versions can be placed in a lexicographical sequence."/>
       <min value="0"/>
       <max value="1"/>
     </element>

--- a/input/definitions/StructureDefinition/StructureDefinition-structuredefinition-inheritance-control.xml
+++ b/input/definitions/StructureDefinition/StructureDefinition-structuredefinition-inheritance-control.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/fiwg"/>
     </telecom>
   </contact>
-  <description value="A code that controls how an extension is treated when snapshots are generated"/>
+  <description value="A code that controls how an extension is treated when snapshots are generated."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>
@@ -49,8 +49,8 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="Inheritance Control Code"/>
-      <definition value="A code that controls how extensions are treated when snapshots in derived profiles are generated"/>
-      <comment value="Some extensions should be inherited, while others are metadata that don't propagate into derived profiles (or shouldn't)"/>
+      <definition value="A code that controls how extensions are treated when snapshots in derived profiles are generated."/>
+      <comment value="Some extensions should be inherited, while others are metadata that don't propagate into derived profiles (or shouldn't)."/>
       <min value="0"/>
       <max value="1"/>
     </element>

--- a/input/definitions/StructureDefinition/StructureDefinition-structuredefinition-type-characteristics.xml
+++ b/input/definitions/StructureDefinition/StructureDefinition-structuredefinition-type-characteristics.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/fiwg"/>
     </telecom>
   </contact>
-  <description value="A code that indicates that a particular type characteristic and it's associated element definition aspects apply to this type."/>
+  <description value="A code that indicates that a particular type characteristic and its associated element definition aspects apply to this type."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>

--- a/input/definitions/StructureDefinition/StructureDefinition-structuredefinition-type-characteristics.xml
+++ b/input/definitions/StructureDefinition/StructureDefinition-structuredefinition-type-characteristics.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/fiwg"/>
     </telecom>
   </contact>
-  <description value="A code that indicates that a particular type characteristic and it's associated element definition aspects apply to this type"/>
+  <description value="A code that indicates that a particular type characteristic and it's associated element definition aspects apply to this type."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>
@@ -49,8 +49,8 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="Characteristic that applies to the type"/>
-      <definition value="A code that indicates that a particular characteristic applies to this type. The characteristics are associated with the use of particular element definition aspects such as length limitations"/>
-      <comment value="Not all possible definitional characteristics apply to all types; for instance, specifying min/max lengths is only sensible for some types, and min/max values for others"/>
+      <definition value="A code that indicates that a particular characteristic applies to this type. The characteristics are associated with the use of particular element definition aspects such as length limitations."/>
+      <comment value="Not all possible definitional characteristics apply to all types; for instance, specifying min/max lengths is only sensible for some types, and min/max values for others."/>
       <min value="0"/>
       <max value="1"/>
     </element>

--- a/input/definitions/datatypes/StructureDefinition-rendering-xhtml.xml
+++ b/input/definitions/datatypes/StructureDefinition-rendering-xhtml.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/fiwg"/>
     </telecom>
   </contact>
-  <description value="This is an equivalent of the string on which the extension is sent, but includes additional XHTML markup, such as bold, italics, styles, tables, etc. Existing [restrictions on XHTML content](narrative.html#security) apply. Note that using [markdown](StructureDefinition-rendering-markdown.html) allows for greater flexibility of display. Like the [Resource Narrative](narrative.html), this extension may reference binary resources for image content (see note about [referencing images](narrative.html#id))"/>
+  <description value="This is an equivalent of the string on which the extension is sent, but includes additional XHTML markup, such as bold, italics, styles, tables, etc. Existing [restrictions on XHTML content](narrative.html#security) apply. Note that using [markdown](StructureDefinition-rendering-markdown.html) allows for greater flexibility of display. Like the [Resource Narrative](narrative.html), this extension may reference binary resources for image content (see note about [referencing images](narrative.html#id))."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>

--- a/input/definitions/datatypes/StructureDefinition-structuredefinition-extension-meaning.xml
+++ b/input/definitions/datatypes/StructureDefinition-structuredefinition-extension-meaning.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/fiwg"/>
     </telecom>
   </contact>
-  <description value="This extension allows conveying the coded meaning of the extension in instances of the extension"/>
+  <description value="This extension allows conveying the coded meaning of the extension in instances of the extension."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>
@@ -53,7 +53,7 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="The meaning of the extension"/>
-      <definition value="This extension allows conveying the coded meaning of the extension in instances of the extension"/>
+      <definition value="This extension allows conveying the coded meaning of the extension in instances of the extension."/>
       <comment value="This SHOULD be the same as the code that appears in the definition of the extension in StructureDefinition.snapshot.element[0].code."/>
       <min value="0"/>
       <max value="1"/>

--- a/input/definitions/multiple/CodeSystem-obligation.xml
+++ b/input/definitions/multiple/CodeSystem-obligation.xml
@@ -428,10 +428,6 @@
     <display value="SHOULD populate"/>
     <definition value="Conformant applications producing resources SHOULD include this element if a value is known and allowed to be shared.&#xA;Notes: This implementation obligation means that whenever the producer knows the correct value for an element, it should populate it.  This is NOT the same as cardinality, as a 'populate' element can be omitted if no data exists or the data that exists is prohibited from being shared."/>
     <property>
-      <code value="not-selectable"/>
-      <valueBoolean value="true"/>
-    </property>
-    <property>
       <code value="qualifier"/>
       <valueCode value="SHOULD"/>
     </property>

--- a/input/definitions/multiple/StructureDefinition-artifact-editor.xml
+++ b/input/definitions/multiple/StructureDefinition-artifact-editor.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="An individual or organization primarily responsible for internal coherence of the {{title}}."/>
+  <description value="An individual or organization primarily responsible for internal coherence of the artifact."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -53,8 +53,8 @@
   <differential>
     <element id="Extension">
       <path value="Extension"/>
-      <short value="Who edited the {{title}}"/>
-      <definition value="An individual or organization primarily responsible for internal coherence of the {{title}}."/>
+      <short value="Who edited the artifact"/>
+      <definition value="An individual or organization primarily responsible for internal coherence of the artifact."/>
       <min value="0"/>
       <max value="*"/>
     </element>

--- a/input/definitions/multiple/StructureDefinition-artifact-endorser.xml
+++ b/input/definitions/multiple/StructureDefinition-artifact-endorser.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="An individual or organization responsible for officially endorsing the {{title}} for use in some setting."/>
+  <description value="An individual or organization responsible for officially endorsing the artifact for use in some setting."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -53,8 +53,8 @@
   <differential>
     <element id="Extension">
       <path value="Extension"/>
-      <short value="Who endorsed the {{title}}"/>
-      <definition value="An individual or organization responsible for officially endorsing the {{title}} for use in some setting."/>
+      <short value="Who endorsed the artifact"/>
+      <definition value="An individual or organization responsible for officially endorsing the artifact for use in some setting."/>
       <min value="0"/>
       <max value="*"/>
     </element>

--- a/input/definitions/multiple/StructureDefinition-artifact-reviewer.xml
+++ b/input/definitions/multiple/StructureDefinition-artifact-reviewer.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/dss"/>
     </telecom>
   </contact>
-  <description value="An individual or organization primarily responsible for review of some aspect of the {{title}}."/>
+  <description value="An individual or organization primarily responsible for review of some aspect of the artifact."/>
   <purpose value="This extension is defined to support representing artifact metadata on resources that are not already canonical resources that have the corresponding element, and that behave in a definitional way. For example, it would not be appropriate to use this extension on a patient-specific resource such as MedicationRequest or CarePlan."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
@@ -53,8 +53,8 @@
   <differential>
     <element id="Extension">
       <path value="Extension"/>
-      <short value="Who reviewed the {{title}}"/>
-      <definition value="An individual or organization primarily responsible for review of some aspect of the {{title}}."/>
+      <short value="Who reviewed the artifact"/>
+      <definition value="An individual or organization primarily responsible for review of some aspect of the artifact."/>
       <min value="0"/>
       <max value="*"/>
     </element>

--- a/input/definitions/multiple/StructureDefinition-obligation.xml
+++ b/input/definitions/multiple/StructureDefinition-obligation.xml
@@ -28,7 +28,7 @@
       <value value="http://www.hl7.org/Special/committees/fiwg"/>
     </telecom>
   </contact>
-  <description value="When appearing on an element, documents obligations that apply to applications implementing that element.  When appearing at the root of a StructureDefinition, indicates obligations that apply to all listed elements within the extension.  When appearing on a type, indicates obligations that apply to the use of that specific type. The obligations relate to application behaviour, not the content of the element itself in the resource instances that contain this element. See the [Obligation](obligations.html) page in the core specification for further detail"/>
+  <description value="When appearing on an element, documents obligations that apply to applications implementing that element.  When appearing at the root of a StructureDefinition, indicates obligations that apply to all listed elements within the extension.  When appearing on a type, indicates obligations that apply to the use of that specific type. The obligations relate to application behaviour, not the content of the element itself in the resource instances that contain this element. See the [Obligation](obligations.html) page in the core specification for further detail."/>
   <jurisdiction>
     <coding>
       <system value="http://unstats.un.org/unsd/methods/m49/m49.htm"/>
@@ -57,7 +57,7 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="Obligations for applications using element/in model"/>
-      <definition value="When appearing on an element, documents obligations that apply to applications implementing that element.  When appearing at the root of a StructureDefinition, indicates obligations that apply to all listed elements within the extension.  When appearing on a type, indicates obligations that apply to the use of that specific type. The obligations relate to application behaviour, not the content of the element itself in the resource instances that contain this element. See [Obligation Extension](obligations.html) for further detail"/>
+      <definition value="When appearing on an element, documents obligations that apply to applications implementing that element.  When appearing at the root of a StructureDefinition, indicates obligations that apply to all listed elements within the extension.  When appearing on a type, indicates obligations that apply to the use of that specific type. The obligations relate to application behaviour, not the content of the element itself in the resource instances that contain this element. See [Obligation Extension](obligations.html) for further detail."/>
       <min value="0"/>
       <max value="*"/>
     </element>

--- a/input/definitions/multiple/StructureDefinition-structuredefinition-conformance-derivedFrom.xml
+++ b/input/definitions/multiple/StructureDefinition-structuredefinition-conformance-derivedFrom.xml
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/fiwg"/>
     </telecom>
   </contact>
-  <description value="Indicates one of the resources that was used to infer the specified maturity or standards status"/>
+  <description value="Indicates one of the resources that was used to infer the specified maturity or standards status."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>
@@ -53,7 +53,7 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="FMM Level"/>
-      <definition value="Indicates one of the resources that was used to infer the specified maturity or standards status"/>
+      <definition value="Indicates one of the resources that was used to infer the specified maturity or standards status."/>
       <min value="0"/>
       <max value="*"/>
     </element>


### PR DESCRIPTION
https://jira.hl7.org/browse/FHIR-45265

The obligation valueSet (https://build.fhir.org/ig/HL7/fhir-extensions/ValueSet-obligation.html) uses a filter to prevent use/validation of codes identified as 'not-selectable'. We believe not-selectable should be removed and the 'populate' could be modified with the SHOULD modifier in guides that intend to provide best practice recommendations that derivative guides will further constrain for conformance purposes.