### PR TITLE
Fix template issue - remove feedback_form reference

### DIFF
--- a/core-dup-template/includes/fragment-pageend.html
+++ b/core-dup-template/includes/fragment-pageend.html
@@ -189,8 +189,6 @@ $( '#tabs' ).tabs({
   <script>anchors.options.visible = 'hover'
 anchors.add()</script>
   
-{% include fragment-feedback_form.html %}
-
   <!-- Analytics Below
   ================================================== -->
 {% endif %}


### PR DESCRIPTION
There was a copy of the base update which has now been fixed for security reasons.  The extensions IG template needed this removed too.