### PR TITLE
FHIR-46438 - Add observation-componentCategory standard extension

### DIFF
--- a/input/definitions/Observation/StructureDefinition-observation-componentCategory.xml
+++ b/input/definitions/Observation/StructureDefinition-observation-componentCategory.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="observation-componentCategory"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="oo"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="0"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="trial-use"/>
+  </extension>
+  <url value="http://hl7.org/fhir/StructureDefinition/observation-componentCategory"/>
+  <version value="5.0.0"/>
+  <name value="ObsComponentCategory"/>
+  <title value="Observation Component Category Code"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <date value="2024-07-20"/>
+  <publisher value="HL7 International / Orders and Observations"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://www.hl7.org/Special/committees/orders"/>
+    </telecom>
+  </contact>
+  <description value="A code that classifies the general type of observation being made in the component."/>
+  <fhirVersion value="5.0.0"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <context>
+    <type value="element"/>
+    <expression value="Observation.component"/>
+  </context>
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="Extension">
+      <path value="Extension"/>
+      <short value="Classification of type of observation component"/>
+      <definition value="A code that classifies the general type of observation being made in the component."/>
+      <comment value="In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set."/>
+      <requirements value="Used for filtering what observations are retrieved and displayed."/>
+      <min value="0"/>
+      <max value="*"/>
+    </element>
+    <element id="Extension.extension">
+      <path value="Extension.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org/fhir/StructureDefinition/observation-componentCategory"/>
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]"/>
+      <min value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="ObservationComponentCategory"/>
+        </extension>
+        <strength value="preferred"/>
+        <description value="Codes for high level observation categories of the component."/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/observation-category"/>
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>


### PR DESCRIPTION
This extension adds a CodeableConcept element which allows including one or more category codes at the level of Observation.component, in addition to the category code(s) that can currently be specified at the Observation resource level.

This is needed for the revised version of the observation vital signs profiles - specifically the BP panel profile, which has required component slices defined for systolic and diastolic BP.  Without this extension, there is not a way to add a required category code that is directly associated with the required component slice.