### PR TITLE
FHIR-43302 Allow Person Context for patient-birthTime extension

### DIFF
--- a/input/definitions/Patient/StructureDefinition-patient-birthTime.xml
+++ b/input/definitions/Patient/StructureDefinition-patient-birthTime.xml
@@ -18,7 +18,7 @@
   </identifier>
   <version value="5.0.0"/>
   <name value="PatBirthTime"/>
-  <title value="Patient Birth Time"/>
+  <title value="Patient/Person/RelatedPerson/Practitioner Birth Time"/>
   <status value="active"/>
   <experimental value="false"/>
   <date value="2020-12-28T16:55:11+11:00"/>
@@ -29,7 +29,7 @@
       <value value="http://www.hl7.org/Special/committees/pafm"/>
     </telecom>
   </contact>
-  <description value="The time of day that the Patient was born. This includes the date to ensure that the timezone information can be communicated effectively."/>
+  <description value="The time of day that the Patient/Person/RelatedPerson/Practitioner was born. This includes the date to ensure that the timezone information can be communicated effectively."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>
@@ -42,6 +42,18 @@
     <type value="element"/>
     <expression value="Patient.birthDate"/>
   </context>
+  <context>
+    <type value="element"/>
+    <expression value="Person.birthDate"/>
+  </context>
+  <context>
+    <type value="element"/>
+    <expression value="RelatedPerson.birthDate"/>
+  </context>
+  <context>
+    <type value="element"/>
+    <expression value="Practitioner.birthDate"/>
+  </context>
   <type value="Extension"/>
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
   <derivation value="constraint"/>
@@ -49,7 +61,8 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="Time of day of birth"/>
-      <definition value="The time of day that the Patient was born. This includes the date to ensure that the timezone information can be communicated effectively."/>
+      <definition value="The time of day that the Patient/Person/RelatedPerson/Practitioner was born. This includes the date to ensure that the timezone information can be communicated effectively."/>
+      <comment value="The patient prefix on the extension was retained to ensure backward compatibility with existing data (the content itself is provided to assist in sharing data across patient resources effectively)"/>
       <min value="0"/>
       <max value="1"/>
     </element>


### PR DESCRIPTION
Expand the scope of the patient-birthTime extension to also cover Person, RelatedPerson and Practitioner.