### PR TITLE
Added new extensions Device mode, cycle and duration https://jira.hl7.org/browse/FHIR-47323

### DIFF
--- a/input/definitions/Device/StructureDefinition-device-operation-cycle.xml
+++ b/input/definitions/Device/StructureDefinition-device-operation-cycle.xml
@@ -1,0 +1,60 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="device-operation-cycle"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="oo"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="trial-use"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/>
+  </extension>
+  <url value="http://hl7.org/fhir/StructureDefinition/device-operation-cycle"/>
+  <version value="5.0.0"/>
+  <name value="DeviceOperationCycle"/>
+  <title value="Device Operation Cycle"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <date value="2025-07-15"/>
+  <publisher value="HL7 International / Orders and Observations"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://www.hl7.org/Special/committees/orders"/>
+    </telecom>
+  </contact>
+  <description value="Count of operating cycles, e.g., the number of measurements taken by the device."/>
+  <fhirVersion value="5.0.0"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <context>
+    <type value="element"/>
+    <expression value="Device"/>
+  </context>
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="Extension">
+      <path value="Extension"/>
+      <short value="Device operation cycle count"/>
+      <definition value="Count of operating cycles, e.g., the number of measurements taken by the device."/>
+      <comment value="The definition of this extension is derived from a concept defined in the ISO/IEEE 11073-10207 standard. The 2019 edition of that standard does not provide further semantics, such as the starting point of the count (e.g., since first installation, factory reset or last power-up of the device). Such further semantics may be defined in later editions."/>
+      <max value="1"/>
+    </element>
+    <element id="Extension.extension">
+      <path value="Extension.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org/fhir/StructureDefinition/device-operation-cycle"/>
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]"/>
+      <type>
+        <code value="Count"/>
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/definitions/Device/StructureDefinition-device-operation-duration.xml
+++ b/input/definitions/Device/StructureDefinition-device-operation-duration.xml
@@ -1,0 +1,54 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="device-operation-duration"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="oo"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="trial-use"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/>
+  </extension>
+  <url value="http://hl7.org/fhir/StructureDefinition/device-operation-duration"/>
+  <version value="5.0.0"/>
+  <name value="DeviceOperationDuration"/>
+  <title value="Device Operation Duration"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <date value="2025-07-15"/>
+  <publisher value="HL7 International / Orders and Observations"/>
+  <description value="Length of time of the device's operation (e.g., days, hours, mins, etc.)."/>
+  <fhirVersion value="5.0.0"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <context>
+    <type value="element"/>
+    <expression value="Device"/>
+  </context>
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="Extension">
+      <path value="Extension"/>
+      <short value="Device operation duration"/>
+      <definition value="Length of time of the device's operation (e.g., days, hours, mins, etc.)."/>
+       <comment value="The current definition of this extension does not provide further semantics, such as the starting point of time of device operation (e.g., since first installation, factory reset or last power-up of the device)."/>
+      <max value="1"/>
+    </element>
+    <element id="Extension.extension">
+      <path value="Extension.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org/fhir/StructureDefinition/device-operation-duration"/>
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]"/>
+      <type>
+        <code value="Duration"/>
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/definitions/Device/StructureDefinition-device-operation-mode.xml
+++ b/input/definitions/Device/StructureDefinition-device-operation-mode.xml
@@ -1,0 +1,63 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="device-operation-mode"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="oo"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="trial-use"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/>
+  </extension>
+  <url value="http://hl7.org/fhir/StructureDefinition/device-operation-mode"/>
+  <version value="5.0.0"/>
+  <name value="DeviceOperationMode"/>
+  <title value="Device Operation Mode"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <date value="2025-07-15"/>
+  <publisher value="HL7 International / Orders and Observations"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://www.hl7.org/Special/committees/orders"/>
+    </telecom>
+  </contact>
+  <description value="The mode of operation of the device (e.g., maintenance, demo, normal)."/>
+  <fhirVersion value="5.0.0"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <context>
+    <type value="element"/>
+    <expression value="Device"/>
+  </context>
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="Extension">
+      <path value="Extension"/>
+      <short value="Device mode of operation"/>
+      <definition value="The mode of operation of the device (e.g., maintenance, demo, normal)."/>
+      <max value="1"/>
+    </element>
+    <element id="Extension.extension">
+      <path value="Extension.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org/fhir/StructureDefinition/device-operation-mode"/>
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <binding>
+        <strength value="example"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/device-operation-mode"/>
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>


### PR DESCRIPTION
….org/browse/FHIR-47323


# Extensions Pack Pull Request
NOTE: In the check-lists below, work groups are asked to attest that they've checked for overlapping functionality.  This means that they've checked that the extension either does not overlap functionality of other existing core elements or extensions (including HL7 IG-published extensions) or clearly defines how to manage such overlap such that it's clear when implementers should use this extension in preference to other approaches.

_(If there's more than one extension, repeat the following one for each that has different answers)_

**Extension Name**: _Device-operation-mode, Device-operation-cycle, Device-operation-duration__ _(not needed if only one extension or all answers are the same for all extensions)_
[x ] **-** New extension  _(complete 'new extension' section below)_
[ ] **-** Updated extension  _(complete 'updated extension' section below)_

### New extension
**Approving Work Group**: _Orders & Observations___________
**Approval Minutes (link)**: ___https://confluence.hl7.org/spaces/DOF/pages/288072164/2024-12-11+Wednesday+DEV+WG+and+DoF_________
_Indicate the work group(s) that are responsible for the extension context(s) if different from above work group_
| Work Group | Extension context(s) | Approval Minutes Link | Overlap checked? |
| ---------- | -------------------- | --------------------- |------------------|
|   Orders & Observations         |      Device                |      https://confluence.hl7.org/spaces/FAST/pages/281219116/2024-11-07+Interoperable+Digital+Identity+Patient+Matching+Meeting                 |        Yes          |

(FHIR-I is the work group if the context is Resource, DomainResource, or Element)_

### Updated extension
Please attest to one of the following:
[ ] **-** This PR contains **no breaking changes** from the previous version of the extension
[ ] **-** This extension is marked as 'draft' and is not referenced in any known published specifications or used in any implementations.
[ ] **-** This PR does not meet ether of the above, but has received FMG approval as documented in their minutes here: _____

If the extension revision adds or removes scopes for content not owned by the work group requesting the change, 
please indicate the approvals of the impacted work group(s) below:
| Work Group | Extension context(s) | Approval Minutes Link | Overlap checked? |
| ---------- | -------------------- | --------------------- |------------------|
|            |                      |                       |                  |
