### PR TITLE
https://jira.hl7.org/browse/FHIR-56303 - enforce HtmlChecks on render…

### DIFF
--- a/input/definitions/datatypes/StructureDefinition-rendering-xhtml.xml
+++ b/input/definitions/datatypes/StructureDefinition-rendering-xhtml.xml
@@ -1,77 +1,82 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="rendering-xhtml"/>
-  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
-    <valueCode value="fhir"/>
-  </extension>
-  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="3"/>
-  </extension>
-  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="trial-use"/>
-  </extension>
-  <url value="http://hl7.org/fhir/StructureDefinition/rendering-xhtml"/>
-  <identifier>
-    <system value="urn:ietf:rfc:3986"/>
-    <value value="urn:oid:2.16.840.1.113883.4.642.5.1573"/>
-  </identifier>
-  <version value="5.0.0"/>
-  <name value="XhtmlRepresentation"/>
-  <title value="XHTML Representation"/>
-  <status value="active"/>
-  <experimental value="false"/>
-  <date value="2014-04-23"/>
-  <publisher value="HL7 International / FHIR Infrastructure"/>
-  <contact>
-    <telecom>
-      <system value="url"/>
-      <value value="http://www.hl7.org/Special/committees/fiwg"/>
-    </telecom>
-  </contact>
-  <description value="This is an equivalent of the string on which the extension is sent, but includes additional XHTML markup, such as bold, italics, styles, tables, etc. Existing [restrictions on XHTML content](narrative.html#security) apply. Note that using [markdown](StructureDefinition-rendering-markdown.html) allows for greater flexibility of display. Like the [Resource Narrative](narrative.html), this extension may reference binary resources for image content (see note about [referencing images](narrative.html#id))."/>
-  <fhirVersion value="5.0.0"/>
-  <mapping>
-    <identity value="rim"/>
-    <uri value="http://hl7.org/v3"/>
-    <name value="RIM Mapping"/>
-  </mapping>
-  <kind value="complex-type"/>
-  <abstract value="false"/>
-  <context>
-    <type value="element"/>
-    <expression value="string"/>
-  </context>
-  <type value="Extension"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
-  <derivation value="constraint"/>
-  <differential>
-    <element id="Extension">
-      <path value="Extension"/>
-      <short value="String equivalent with html markup"/>
-      <definition value="This is an equivalent of the string on which the extension is sent, but includes additional XHTML markup, such as bold, italics, styles, tables, etc. Existing [restrictions on XHTML content](narrative.html#security) apply. Note that using [markdown](StructureDefinition-rendering-markdown.html) allows for greater flexibility of display."/>
-      <comment value="For questionnaires, see additional guidance and examples in the [SDC implementation guide](http://hl7.org/fhir/uv/sdc/2025Jan/rendering.html#rendering-xhtml)."/>
-      <min value="0"/>
-      <max value="1"/>
-      <mapping>
-        <identity value="rim"/>
-        <map value="ED can be XHTML content"/>
-      </mapping>
-    </element>
-    <element id="Extension.extension">
-      <path value="Extension.extension"/>
-      <max value="0"/>
-    </element>
-    <element id="Extension.url">
-      <path value="Extension.url"/>
-      <fixedUri value="http://hl7.org/fhir/StructureDefinition/rendering-xhtml"/>
-    </element>
-    <element id="Extension.value[x]">
-      <path value="Extension.value[x]"/>
-      <min value="1"/>
-      <type>
-        <code value="string"/>
-      </type>
-    </element>
-  </differential>
+<StructureDefinition xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../../input-cache/schemas/R5/fhir-single.xsd">
+	<id value="rendering-xhtml"/>
+	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+		<valueCode value="fhir"/>
+	</extension>
+	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+		<valueInteger value="3"/>
+	</extension>
+	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+		<valueCode value="trial-use"/>
+	</extension>
+	<url value="http://hl7.org/fhir/StructureDefinition/rendering-xhtml"/>
+	<identifier>
+		<system value="urn:ietf:rfc:3986"/>
+		<value value="urn:oid:2.16.840.1.113883.4.642.5.1573"/>
+	</identifier>
+	<version value="5.0.0"/>
+	<name value="XhtmlRepresentation"/>
+	<title value="XHTML Representation"/>
+	<status value="active"/>
+	<experimental value="false"/>
+	<date value="2014-04-23"/>
+	<publisher value="HL7 International / FHIR Infrastructure"/>
+	<contact>
+		<telecom>
+			<system value="url"/>
+			<value value="http://www.hl7.org/Special/committees/fiwg"/>
+		</telecom>
+	</contact>
+	<description value="This is an equivalent of the string on which the extension is sent, but includes additional XHTML markup, such as bold, italics, styles, tables, etc. Existing [restrictions on XHTML content](narrative.html#security) apply. Note that using [markdown](StructureDefinition-rendering-markdown.html) allows for greater flexibility of display. Like the [Resource Narrative](narrative.html), this extension may reference binary resources for image content (see note about [referencing images](narrative.html#id))."/>
+	<fhirVersion value="5.0.0"/>
+	<mapping>
+		<identity value="rim"/>
+		<uri value="http://hl7.org/v3"/>
+		<name value="RIM Mapping"/>
+	</mapping>
+	<kind value="complex-type"/>
+	<abstract value="false"/>
+	<context>
+		<type value="element"/>
+		<expression value="string"/>
+	</context>
+	<type value="Extension"/>
+	<baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+	<derivation value="constraint"/>
+	<differential>
+		<element id="Extension">
+			<path value="Extension"/>
+			<short value="String equivalent with html markup"/>
+			<definition value="This is an equivalent of the string on which the extension is sent, but includes additional XHTML markup, such as bold, italics, styles, tables, etc. Existing [restrictions on XHTML content](narrative.html#security) apply. Note that using [markdown](StructureDefinition-rendering-markdown.html) allows for greater flexibility of display."/>
+			<comment value="For questionnaires, see additional guidance and examples in the [SDC implementation guide](http://hl7.org/fhir/uv/sdc/2025Jan/rendering.html#rendering-xhtml)."/>
+			<min value="0"/>
+			<max value="1"/>
+			<mapping>
+				<identity value="rim"/>
+				<map value="ED can be XHTML content"/>
+			</mapping>
+		</element>
+		<element id="Extension.extension">
+			<path value="Extension.extension"/>
+			<max value="0"/>
+		</element>
+		<element id="Extension.url">
+			<path value="Extension.url"/>
+			<fixedUri value="http://hl7.org/fhir/StructureDefinition/rendering-xhtml"/>
+		</element>
+		<element id="Extension.value[x]">
+			<path value="Extension.value[x]"/>
+			<min value="1"/>
+			<type>
+				<code value="string"/>
+			</type>
+			<constraint>
+        <key value="xhtml-ext-1"/>
+        <severity value="error"/>
+        <human value="The XHTML contained here SHALL abide by the same constraints as narrative.  I.e. contain only the basic html formatting elements and attributes described in chapters 7-11 (except section 4 of chapter 9) and 15 of the HTML 4.0 standard, &lt;a&gt; elements (either name or href), images and internally contained style attributes"/>
+        <expression value="htmlChecks()"/>
+      </constraint>
+		</element>
+	</differential>
 </StructureDefinition>


### PR DESCRIPTION
# Extensions Pack Pull Request
NOTE: In the check-lists below, work groups are asked to attest that they've checked for overlapping functionality.  This means that they've checked that the extension either does not overlap functionality of other existing core elements or extensions (including HL7 IG-published extensions) or clearly defines how to manage such overlap such that it's clear when implementers should use this extension in preference to other approaches.

_(If there's more than one extension, repeat the following one for each that has different answers)_

**Extension Name**: render-html
[x] **-** Updated extension  _(complete 'updated extension' section below)_

### New extension
**Approving Work Group**: FHIR-I
**Approval Minutes (link)**: https://confluence.hl7.org/spaces/FHIRI/pages/453904223/FHIR+SDC+Minutes+CC+20260409

### Updated extension
Please attest to one of the following:
[x ] **-** This PR contains **no breaking changes** from the previous version of the extension
