### PR TITLE
FHIR-56275: Adds artifact-authoritativeSource extension and deprecates valueset-authoritativeSource

### DIFF
--- a/input/definitions/CodeSystem/StructureDefinition-codesystem-authoritativeSource.xml
+++ b/input/definitions/CodeSystem/StructureDefinition-codesystem-authoritativeSource.xml
@@ -11,7 +11,7 @@
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
     <valueCode value="deprecated">
       <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status-reason">
-        <valueMarkdown value="This extension has been deprecated due to being poorly defined."/>
+        <valueMarkdown value="This extension has been deprecated in favor of the more general artifact-authoritativeSource resource."/>
       </extension>
     </valueCode>
   </extension>
@@ -33,7 +33,7 @@
       <value value="http://www.hl7.org/Special/committees/Vocab"/>
     </telecom>
   </contact>
-  <description value="A reference to the authoritative, human readable, source of truth for the code system information.  This extension has been deprecated due to being poorly defined.  External code system information can be found in THO or the relevant HTA confluence pages."/>
+  <description value="DEPRECATED: Use artifact-authoritativeSource instead. A reference to the authoritative, human readable, source of truth for the code system information. External code system information can be found in THO or the relevant HTA confluence pages."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>
@@ -53,7 +53,7 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="Reference to the current trusted source of the CodeSystem resource"/>
-      <definition value="A reference to the authoritative, human readable, source of truth for the code system information."/>
+      <definition value="DEPRECATED: Use artifact-authoritativeSource instead. A reference to the authoritative, human readable, source of truth for the code system information."/>
       <comment value="If this extension is not present, then the canonical URL (CodeSystem.url) also serves the purpose of specifying the authoritative source.  A difference between the canonical URL and the authoritiative source might arise in some cases due to ongoing organization restructuring, etc., and in those cases this extension may be used.  The URL of the authoritative source is intended to be resolvable but that cannot be guaranteed."/>
       <min value="0"/>
       <max value="1"/>

--- a/input/definitions/Resource/StructureDefinition-artifact-authoritativeSource.json
+++ b/input/definitions/Resource/StructureDefinition-artifact-authoritativeSource.json
@@ -1,0 +1,89 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "artifact-authoritativeSource",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
+      "valueInteger": 1
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+      "valueCode": "cds"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+      "valueCode": "trial-use"
+    }
+  ],
+  "url": "http://hl7.org/fhir/StructureDefinition/artifact-authoritativeSource",
+  "name": "ArtifactAuthoritativeSource",
+  "title": "Artifact Authoritative Source",
+  "status": "active",
+  "experimental": false,
+  "date": "2026-04-20T11:44:32-06:00",
+  "publisher": "HL7 International / Clinical Decision Support",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.hl7.org/Special/committees/dss"
+        }
+      ]
+    }
+  ],
+  "description": "A reference to the offical/source of truth definition of the content, typically outside the FHIR ecosystem. For example, the authoritativeSource for a ValueSet might be a spreadsheet published on an agency website.",
+  "purpose": "To provide the official source of truth for the definition of an artifact, typically when that source of truth definition is not represented in FHIR.",
+  "fhirVersion": "5.0.0",
+  "mapping": [
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    }
+  ],
+  "kind": "complex-type",
+  "abstract": false,
+  "context": [
+    {
+      "type": "element",
+      "expression": "DomainResource"
+    }
+  ],
+  "type": "Extension",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Extension",
+        "path": "Extension",
+        "short": "Original definitions",
+        "definition": "A reference to the offical/source of truth definition of the content, typically outside the FHIR ecosystem. For example, the authoritativeSource for a ValueSet might be a spreadsheet published on an agency website.",
+        "comment": "Note that this concept is different from web-source (where the page for the content can be found it is different from the canonical), and package-source (what package the resource came from). This is an abbreviated way of saying something that could be expressed with Provenance. This extensions points to the content, not the authority for the content.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "type": [
+          {
+            "code": "uri"
+          }
+        ],
+        "fixedUri": "http://hl7.org/fhir/StructureDefinition/artifact-authoritativeSource"
+      },
+      {
+        "id": "Extension.value[x]",
+        "path": "Extension.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "uri"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/input/definitions/ValueSet/StructureDefinition-valueset-authoritativeSource.xml
+++ b/input/definitions/ValueSet/StructureDefinition-valueset-authoritativeSource.xml
@@ -9,7 +9,11 @@
     <valueInteger value="3"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="trial-use"/>
+    <valueCode value="deprecated">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status-reason">
+        <valueMarkdown value="This extension has been deprecated in favor of the more general artifact-authoritativeSource resource."/>
+      </extension>
+    </valueCode>
   </extension>
   <url value="http://hl7.org/fhir/StructureDefinition/valueset-authoritativeSource"/>
   <identifier>
@@ -29,7 +33,7 @@
       <value value="http://www.hl7.org/Special/committees/Vocab"/>
     </telecom>
   </contact>
-  <description value="A reference to the authoritative accessible, persisted source of truth of the entire Value Set Definition, including textual information and available versions."/>
+  <description value="DEPRECATED: Use artifact-authoritativeSource instead. A reference to the authoritative accessible, persisted source of truth of the entire Value Set Definition, including textual information and available versions."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="rim"/>
@@ -49,7 +53,7 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="Reference to the current trusted source of the ValueSet resource (metadata and definition)"/>
-      <definition value="A reference to the authoritative accessible, persisted source of truth of the entire Value Set Definition, including textual information and available versions."/>
+      <definition value="DEPRECATED: Use artifact-authoritativeSource instead. A reference to the authoritative accessible, persisted source of truth of the entire Value Set Definition, including textual information and available versions."/>
       <comment value="If this extension is not present, then the canonical URL (ValueSet.url) also serves the purpose of specifying the authoritative source.  A difference between the canonical URL and the authoritiative source might arise in some cases due to ongoing organization restructuring, etc., and in those cases this extension may be used.  The URL of the authoritative source is intended to be resolvable but that cannot be guaranteed. The designated &quot;authoritative source&quot; is normally expected to be able to generate a valid expansion of the value set, and if for some reason it cannot then the valueset-trusted-expansion should be used."/>
       <min value="0"/>
       <max value="1"/>


### PR DESCRIPTION
[X] **-** New extension  _(complete 'new extension' section below)_
[ ] **-** Updated extension  _(complete 'updated extension' section below)_

### New extension
**Approving Work Group**: FHIR-I
**Approval Minutes (link)**: [FHIR-56275](https://jira.hl7.org/browse/FHIR-56275)

_Indicate the work group(s) that are responsible for the extension context(s) if different from above work group_
| Work Group | Extension context(s) | Approval Minutes Link | Overlap checked? |
| ---------- | -------------------- | --------------------- |------------------|
| TI           |  CodeSystem/ValueSet     |  [FHIR-56401](https://jira.hl7.org/browse/FHIR-56401)    |    X   |
