### PR TITLE
FHIR-56072: Added Device.conformsTo to context of use for artifact-relatedArtifact

### DIFF
--- a/input/definitions/Resource/StructureDefinition-artifact-relatedArtifact.xml
+++ b/input/definitions/Resource/StructureDefinition-artifact-relatedArtifact.xml
@@ -76,6 +76,15 @@
   <context>
     <extension url="http://hl7.org/fhir/StructureDefinition/version-specific-use">
       <extension url="startFhirVersion">
+        <valueCode value="5.0"/>
+      </extension>
+    </extension>
+    <type value="element"/>
+    <expression value="Device.conformsTo"/>
+  </context>
+  <context>
+    <extension url="http://hl7.org/fhir/StructureDefinition/version-specific-use">
+      <extension url="startFhirVersion">
         <valueCode value="4.0"/>
       </extension>
     </extension>


### PR DESCRIPTION
[FHIR-56072](https://jira.hl7.org/browse/FHIR-56072)

[X] **-** Updated extension  _(complete 'updated extension' section below)_

### Updated extension
Please attest to one of the following:
[X] **-** This PR contains **no breaking changes** from the previous version of the extension
[ ] **-** This extension is marked as 'draft' and is not referenced in any known published specifications or used in any implementations.
[ ] **-** This PR does not meet ether of the above, but has received FMG approval as documented in their minutes here: _____

If the extension revision adds or removes scopes for content not owned by the work group requesting the change, 
please indicate the approvals of the impacted work group(s) below:
| Work Group | Extension context(s) | Approval Minutes Link | Overlap checked? |
| ---------- | -------------------- | --------------------- |------------------|
|  OO         | Device.conformsTo    | OO submitted the request  |                  |
