### PR TITLE
FHIR-53021: Fixed status to active

### DIFF
--- a/input/definitions/ValueSet/StructureDefinition-valueset-unclosed.xml
+++ b/input/definitions/ValueSet/StructureDefinition-valueset-unclosed.xml
@@ -19,7 +19,7 @@
   <version value="5.0.0"/>
   <name value="VSUnclosed"/>
   <title value="ValueSet Unclosed"/>
-  <status value="retired"/>
+  <status value="active"/>
   <experimental value="false"/>
   <date value="2020-12-28T16:55:11+11:00"/>
   <publisher value="HL7 International / Terminology Infrastructure"/>


### PR DESCRIPTION
As part of the fix for 53021 (undeprecating the valueset-unclosed extension), I did not notice that the status had been set to retired as part of that earlier change. The status should be set back to active as part of undeprecating (this is causing warnings downstream).