### PR TITLE
FHIR-43081 - Add authorization-hint extension.

### DIFF
--- a/input/definitions/multiple/StructureDefinition-authorization-hint.json
+++ b/input/definitions/multiple/StructureDefinition-authorization-hint.json
@@ -1,0 +1,203 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "authorization-hint",
+  "extension" : [{
+    "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
+    "valueInteger" : 1
+  },
+  {
+    "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+    "valueCode" : "fhir"
+  },
+  {
+    "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+    "valueCode" : "trial-use"
+  }],
+  "url": "http://hl7.org/fhir/StructureDefinition/authorization-hint",
+  "name": "AuthorizationHint",
+  "title": "Authorization Hint",
+  "status": "active",
+  "experimental": false,
+  "date": "2019-02-13",
+  "publisher": "HL7 International / Clinical Decision Support",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.hl7.org/Special/committees/dss"
+        }
+      ]
+    }
+  ],
+  "description": "A hint for authorization requirements used to access content or services.",
+  "purpose": "This extension provides a hint for authorization requirements used to access content or services.",
+  "fhirVersion": "4.0.1",
+  "kind": "complex-type",
+  "abstract": false,
+  "context": [
+    {
+      "type": "element",
+      "expression": "Endpoint"
+    },
+    {
+      "type": "element",
+      "expression": "Organization"
+    },
+    {
+      "extension": [{
+        "url": "http://hl7.org/fhir/StructureDefinition/version-specific-use",
+        "extension": [{
+          "url": "startFhirVersion",
+          "valueCode": "4.3.0"
+        }]
+      }],
+      "type": "element",
+      "expression": "SubscriptionStatus.notificationEvent"
+    },
+    {
+        "type": "element",
+        "expression": "Reference"
+    }
+  ],
+  "type": "Extension",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Extension",
+        "path": "Extension",
+        "short": "A hint for authorization requirements",
+        "definition": "A hint for authorization requirements used to access content or services",
+        "min": 0,
+        "max": "*"
+      },
+      {
+        "id": "Extension.extension",
+        "path": "Extension.extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "ordered": false,
+          "rules": "open"
+        },
+        "min": 0,
+        "max": "*",
+        "base": {
+          "path": "Extension.extension",
+          "min": 1,
+          "max": "*"
+        }
+      },
+      {
+        "id": "Extension.extension:type",
+        "path": "Extension.extension",
+        "sliceName": "type",
+        "short": "Authorization Type",
+        "definition": "Used by clients to determine what kind of authorization is appropriate in this context.",
+        "min": 1,
+        "max": "1",
+        "base": {
+          "path": "Extension.extension",
+          "min": 0,
+          "max": "*"
+        }
+      },
+      {
+        "id": "Extension.extension:type.url",
+        "path": "Extension.extension.url",
+        "min": 1,
+        "max": "1",
+        "base": {
+          "path": "Extension.url",
+          "min": 1,
+          "max": "1"
+        },
+        "fixedUri": "type"
+      },
+      {
+        "id": "Extension.extension:type.value[x]",
+        "path": "Extension.extension.value[x]",
+        "short": "Authorization Type",
+        "definition": "Used by clients to determine what kind of authorization is appropriate in this context.",
+        "min": 1,
+        "max": "1",
+        "base": {
+          "path": "Extension.value[x]",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "Coding"
+          }
+        ]
+      },
+      {
+        "id": "Extension.extension:value",
+        "path": "Extension.extension",
+        "sliceName": "value",
+        "short": "Authorization Value",
+        "definition": "A value related to the declared authorization type (e.g., a token).",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Extension.extension",
+          "min": 0,
+          "max": "*"
+        }
+      },
+      {
+        "id": "Extension.extension:value.url",
+        "path": "Extension.extension.url",
+        "min": 1,
+        "max": "1",
+        "base": {
+          "path": "Extension.url",
+          "min": 1,
+          "max": "1"
+        },
+        "fixedUri": "value"
+      },
+      {
+        "id": "Extension.extension:value.value[x]",
+        "path": "Extension.extension.value[x]",
+        "short": "Authorization Value",
+        "definition": "A value related to the declared authorization type (e.g., a token).",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Extension.value[x]",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "type": [
+          {
+            "code": "uri"
+          }
+        ],
+        "fixedUri": "http://hl7.org/fhir/StructureDefinition/authorization-hint"
+      },
+      {
+        "id": "Extension.value[x]",
+        "path": "Extension.value[x]",
+        "min": 0,
+        "max": "0"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Note that this extension does not yet have a terminology binding - waiting on UTG process.


# Extensions Pack Pull Request
NOTE: In the check-lists below, work groups are asked to attest that they've checked for overlapping functionality.  This means that they've checked that the extension either does not overlap functionality of other existing core elements or extensions (including HL7 IG-published extensions) or clearly defines how to manage such overlap such that it's clear when implementers should use this extension in preference to other approaches.

_(If there's more than one extension, repeat the following one for each that has different answers)_

**Extension Name**: authorization-hint 
[x] **-** New extension  _(complete 'new extension' section below)_
[ ] **-** Updated extension  _(complete 'updated extension' section below)_

### New extension
**Approving Work Group**: FHIR Infrastructure
**Approval Minutes (link)**: [FHIR-I Minutes 2023-11-13](https://confluence.hl7.org/spaces/FHIRI/pages/204276814/FHIR+Infrastructure+Minutes+CC+2023-11-13)
_Indicate the work group(s) that are responsible for the extension context(s) if different from above work group_
| Work Group | Extension context(s) | Approval Minutes Link | Overlap checked? |
| ---------- | -------------------- | --------------------- |------------------|
|            |                      |                       |                  |

(FHIR-I is the work group if the context is Resource, DomainResource, or Element)_
